### PR TITLE
WIP: Add the environment variable config mode

### DIFF
--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -1,16 +1,23 @@
 ---
 - hosts: masters
   tasks:
-  - name: Create kube-vip config directory
-    file:
-      path: /etc/kube-vip
-      state: directory
-      mode: 0755
+  - name: Initalize config variables
+    set_fact:
+      kube_vip_config_mode: "{{ kube_vip_config_mode | default('file') }}"
+      kube_vip_port: "{{ kube_vip_port | default(10000) }}"
 
-  - name: Write kube-vip config file"
-    template:
-      src: ../templates/config.yaml.j2
-      dest: /etc/kube-vip/config.yaml
+  - when: kube_vip_config_mode == "file"
+    block:
+    - name: Create kube-vip config directory
+      file:
+        path: /etc/kube-vip
+        state: directory
+        mode: 0755
+
+    - name: Write kube-vip config file
+      template:
+        src: ../templates/config.yaml.j2
+        dest: /etc/kube-vip/config.yaml
 
   - name: Create kubelet static pod manifest directory
     file:

--- a/templates/kube-vip.yaml.js
+++ b/templates/kube-vip.yaml.js
@@ -7,8 +7,37 @@ spec:
   containers:
   - args:
     - start
+{% if kube_vip_config_mode == "file" %}
     - -c
     - /etc/kube-vip/config.yaml
+{% endif %}
+{% if kube_vip_config_mode == "env" %}
+    env:
+    - name: vip_localpeer
+      value: "{{ inventory_hostname }}:{{ ansible_default_ipv4.address }}:{{ kube_vip_port | default(10000) }}"
+    - name: vip_remotepeers
+      value: "{% for name in groups.masters | difference(inventory_hostname) %}{{ name }}:{{ hostvars[name].ansible_default_ipv4.address }}:{{ kube_vip_port | default(10000) }}{% if not loop.last %},{% endif %}{% endfor %}"
+    - name: vip_address
+      value: "{{ kube_vip_vip_address_ipv4 | default('') }}"
+    - name: vip_arp
+      value: "{{ kube_vip_gratuitous_arp | default('false') }}"
+    - name: vip_singenode
+      value: "false"
+    - name: vip_startleader
+      value: "{{ inventory_hostname == groups.masters.0 | ternary('true', 'false') }}"
+    - name: vip_interface
+      value: "{{ ansible_default_ipv4.interface }}"
+    - name: lb_name
+      value: "OpenShift Control Plane"
+    - name: lb_type
+      value: "tcp"
+    - name: lb_port
+      value: "9443"
+    - name: lb_bindtovip
+      value: "true"
+    - name: lb_backends
+      value: "{% for name in [inventory_hostname] + (groups.masters | difference(inventory_hostname)) %}{{ name }}:{{ hostvars[name].ansible_default_ipv4.address }}:8443{% if not loop.last %},{% endif %}{% endfor %}"
+{% endif %}
     image: docker.io/plndr/kube-vip:0.1.5
     name: kube-vip
     securityContext:
@@ -16,12 +45,16 @@ spec:
         add:
         - NET_ADMIN
         - SYS_TIME
+{% if kube_vip_config_mode == "file" %}
     volumeMounts:
     - mountPath: /etc/kube-vip/
       name: config
+{% endif %}
   hostNetwork: true
   priorityClassName: system-node-critical
+{% if kube_vip_config_mode == "file" %}
   volumes:
   - hostPath:
       path: /etc/kube-vip/
     name: config
+{% endif %}


### PR DESCRIPTION
kube-vip can be configured just by environment variables.
This would prevent using an external config file.